### PR TITLE
added composer for testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,5 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+
+/vendor/

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,25 @@
+{
+    "name": "moh/bld",
+    "autoload": {
+        "psr-4": {
+            "Moh\\Bld\\": "src/"
+        },
+        "classmap": [
+            "public/html/index.php"
+        ]
+    },
+    "authors": [
+        {
+            "name": "5rod",
+            "email": "2158177@talnet.nl"
+        }
+    ],
+    "require": {
+
+    },
+    "config": {
+        "platform": {
+            "php": "8.2.12"
+        }
+    }
+}

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,21 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "43ba62bfb693cc4a5fa4fc266ba5d601",
+    "packages": [],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": {},
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {},
+    "platform-dev": {},
+    "platform-overrides": {
+        "php": "8.2.12"
+    },
+    "plugin-api-version": "2.6.0"
+}


### PR DESCRIPTION
This pull request adds a new `composer.json` file to set up autoloading, define project metadata, and specify the PHP version for the project.

Key changes:

* **Project setup with Composer**:
  * Added a `composer.json` file to define the project name (`moh/bld`), autoloading configuration (`PSR-4` and `classmap` for `src/` and `public/html/index.php`), and author details.
  * Configured the project to use PHP version `8.2.12` via the `platform` setting.